### PR TITLE
Fix parameter mix-up in the Bybit client and add timestamp field to the JSON payload

### DIFF
--- a/src/main/java/dev/mouradski/ftso/trades/client/binance/BinanceClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/binance/BinanceClientEndpoint.java
@@ -30,7 +30,7 @@ public class BinanceClientEndpoint extends AbstractClientEndpoint {
 
         Pair<String, String> pair = SymbolHelper.getPair(binanceTrade.getData().getS());
 
-        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
+        return Arrays.asList(Trade.builder().timestamp(binanceTrade.getData().getT()).exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
                 .price(binanceTrade.getData().getP()).amount(binanceTrade.getData().getQ()).build());
     }
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/bitfinex/BitfinexClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bitfinex/BitfinexClientEndpoint.java
@@ -18,7 +18,8 @@ public class BitfinexClientEndpoint extends AbstractClientEndpoint {
 
     private Map<Double, Pair<String, String>> channelIds = new HashMap<>();
 
-    public BitfinexClientEndpoint(TradeService priceSender, @Value("${exchanges}") List<String> exchanges, @Value("${assets}") List<String> assets) {
+    public BitfinexClientEndpoint(TradeService priceSender, @Value("${exchanges}") List<String> exchanges,
+            @Value("${assets}") List<String> assets) {
         super(priceSender, exchanges, assets);
     }
 
@@ -29,7 +30,10 @@ public class BitfinexClientEndpoint extends AbstractClientEndpoint {
 
     @Override
     protected void subscribe() {
-        getAssets().stream().map(String::toUpperCase).forEach(base -> getAllQuotesExceptBusd(true).forEach(quote -> this.sendMessage("{\"event\":\"subscribe\", \"channel\":\"trades\",\"symbol\":\"tSYMBOLQUOTE\"}".replace("SYMBOL", base).replace("QUOTE", quote))));
+        getAssets().stream().map(String::toUpperCase)
+                .forEach(base -> getAllQuotesExceptBusd(true).forEach(quote -> this
+                        .sendMessage("{\"event\":\"subscribe\", \"channel\":\"trades\",\"symbol\":\"tSYMBOLQUOTE\"}"
+                                .replace("SYMBOL", base).replace("QUOTE", quote))));
     }
 
     @Override
@@ -50,7 +54,9 @@ public class BitfinexClientEndpoint extends AbstractClientEndpoint {
 
         var pair = channelIds.get(channelId);
 
-        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(tradeData.get(3)).amount(Math.abs(tradeData.get(2))).build());
+        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
+                .price(tradeData.get(3)).amount(Math.abs(tradeData.get(2))).timestamp(System.currentTimeMillis())
+                .build());
     }
 
     @Override

--- a/src/main/java/dev/mouradski/ftso/trades/client/bitget/BitgetClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bitget/BitgetClientEndpoint.java
@@ -52,7 +52,7 @@ public class BitgetClientEndpoint extends AbstractClientEndpoint {
 
 
         update.getData().forEach(tradeData -> {
-            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).amount(tradeData.getQuantity()).price(tradeData.getPrice()).build());
+            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).amount(tradeData.getQuantity()).price(tradeData.getPrice()).timestamp(System.currentTimeMillis()).build());
         });
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/bitmart/BitmartClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bitmart/BitmartClientEndpoint.java
@@ -35,7 +35,8 @@ public class BitmartClientEndpoint extends AbstractClientEndpoint {
 
     private List<String> supportedSymbols = new ArrayList<>();
 
-    protected BitmartClientEndpoint(TradeService priceSender, @Value("${exchanges}") List<String> exchanges, @Value("${assets}") List<String> assets) {
+    protected BitmartClientEndpoint(TradeService priceSender, @Value("${exchanges}") List<String> exchanges,
+            @Value("${assets}") List<String> assets) {
         super(priceSender, exchanges, assets);
     }
 
@@ -54,8 +55,8 @@ public class BitmartClientEndpoint extends AbstractClientEndpoint {
             }
         }));
 
-
-        this.sendMessage("{\"op\":\"subscribe\",\"args\":[PAIRS]}".replace("PAIRS", pairs.stream().collect(Collectors.joining(","))));
+        this.sendMessage("{\"op\":\"subscribe\",\"args\":[PAIRS]}".replace("PAIRS",
+                pairs.stream().collect(Collectors.joining(","))));
 
     }
 
@@ -105,7 +106,9 @@ public class BitmartClientEndpoint extends AbstractClientEndpoint {
                 .forEach(tradeData -> {
                     var pair = SymbolHelper.getPair(tradeData.getSymbol());
                     trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
-                            .price(tradeData.getPrice()).amount(tradeData.getSize()).build());
+                            .price(tradeData.getPrice()).amount(tradeData.getSize())
+                            .timestamp(tradeData.getS_t() * 1000) // timestamp is in seconds
+                            .build());
 
                 });
 
@@ -117,7 +120,6 @@ public class BitmartClientEndpoint extends AbstractClientEndpoint {
         this.sendMessage("ping");
     }
 
-
     @Override
     protected void prepareConnection() {
         HttpClient client = HttpClient.newHttpClient();
@@ -127,7 +129,8 @@ public class BitmartClientEndpoint extends AbstractClientEndpoint {
 
         try {
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            dev.mouradski.ftso.trades.client.bitmart.SymbolResponse symbolResponse = objectMapper.readValue(response.body(), SymbolResponse.class);
+            dev.mouradski.ftso.trades.client.bitmart.SymbolResponse symbolResponse = objectMapper
+                    .readValue(response.body(), SymbolResponse.class);
 
             this.supportedSymbols = symbolResponse.getData().getSymbols();
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/bitmart/TradeData.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bitmart/TradeData.java
@@ -21,5 +21,8 @@ public class TradeData {
 
     @JsonProperty("symbol")
     private String symbol;
+
+    @JsonProperty("symbol")
+    private Long s_t;
 }
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/bitrue/BitrueClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bitrue/BitrueClientEndpoint.java
@@ -40,7 +40,7 @@ public class BitrueClientEndpoint extends AbstractClientEndpoint {
         var quote = "USDT";
 
         for (var trade : tradeMessage.getTick().getData()) {
-            trades.add(Trade.builder().exchange(getExchange()).price(trade.getPrice()).amount(trade.getAmount()).quote(quote).base(pair).build());
+            trades.add(Trade.builder().exchange(getExchange()).price(trade.getPrice()).amount(trade.getAmount()).quote(quote).base(pair).timestamp(trade.getTs()).build());
         }
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/btcex/BtcexClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/btcex/BtcexClientEndpoint.java
@@ -17,7 +17,8 @@ import java.util.List;
 @ClientEndpoint
 public class BtcexClientEndpoint extends AbstractClientEndpoint {
 
-    protected BtcexClientEndpoint(TradeService priceSender, @Value("${exchanges}") List<String> exchanges, @Value("${assets}") List<String> assets) {
+    protected BtcexClientEndpoint(TradeService priceSender, @Value("${exchanges}") List<String> exchanges,
+            @Value("${assets}") List<String> assets) {
         super(priceSender, exchanges, assets);
     }
 
@@ -40,7 +41,6 @@ public class BtcexClientEndpoint extends AbstractClientEndpoint {
         return "btcex";
     }
 
-
     @Override
     protected List<Trade> mapTrade(String message) throws JsonProcessingException {
         if (!message.contains("trade_id")) {
@@ -54,7 +54,10 @@ public class BtcexClientEndpoint extends AbstractClientEndpoint {
         tradeResponse.getParams().getData().forEach(tradeData -> {
             var pair = SymbolHelper.getPair(tradeData.getInstrumentName().replace("-SPOT", ""));
 
-            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(tradeData.getPrice()).amount(tradeData.getAmount()).build());
+            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
+                    .price(tradeData.getPrice()).amount(tradeData.getAmount())
+                    .timestamp(Long.parseLong(tradeData.getTimestamp()) * 1000) // timestamp is sent in seconds
+                    .build());
         });
 
         return trades;
@@ -62,6 +65,7 @@ public class BtcexClientEndpoint extends AbstractClientEndpoint {
 
     @Scheduled(fixedDelay = 15000)
     public void ping() {
-        this.sendMessage("{ \"jsonrpc\":\"2.0\",\"id\": ID,\"method\": \"/public/ping\",\"params\":{}}".replace("ID", incAndGetIdAsString()));
+        this.sendMessage("{ \"jsonrpc\":\"2.0\",\"id\": ID,\"method\": \"/public/ping\",\"params\":{}}".replace("ID",
+                incAndGetIdAsString()));
     }
 }

--- a/src/main/java/dev/mouradski/ftso/trades/client/btcex/TradeData.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/btcex/TradeData.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 class TradeData {
+    @JsonProperty("timestamp")
     String timestamp;
     Double price;
     Double amount;

--- a/src/main/java/dev/mouradski/ftso/trades/client/btse/BtseClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/btse/BtseClientEndpoint.java
@@ -1,6 +1,5 @@
 package dev.mouradski.ftso.trades.client.btse;
 
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.mouradski.ftso.trades.client.AbstractClientEndpoint;
 import dev.mouradski.ftso.trades.model.Trade;
@@ -17,7 +16,8 @@ import java.util.List;
 @ClientEndpoint
 public class BtseClientEndpoint extends AbstractClientEndpoint {
 
-    protected BtseClientEndpoint(TradeService priceSender, @Value("${exchanges}") List<String> exchanges, @Value("${assets}") List<String> assets) {
+    protected BtseClientEndpoint(TradeService priceSender, @Value("${exchanges}") List<String> exchanges,
+            @Value("${assets}") List<String> assets) {
         super(priceSender, exchanges, assets);
     }
 
@@ -34,7 +34,8 @@ public class BtseClientEndpoint extends AbstractClientEndpoint {
                 .forEach(symbol -> getAllQuotesExceptBusd(true).forEach(quote -> {
                     var symbolId = symbol + "-" + quote;
                     pairs.add("\"tradeHistoryApi:SYMBOL\"".replace("SYMBOL", symbolId));
-                    this.sendMessage("{\"op\": \"subscribe\",\"args\": [\"tradeHistoryApi:SYMBOL\"]}".replace("SYMBOL", symbolId));
+                    this.sendMessage("{\"op\": \"subscribe\",\"args\": [\"tradeHistoryApi:SYMBOL\"]}".replace("SYMBOL",
+                            symbolId));
                 }));
     }
 
@@ -68,7 +69,8 @@ public class BtseClientEndpoint extends AbstractClientEndpoint {
             var pair = SymbolHelper.getPair(tradeHistoryData.getSymbol());
 
             trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
-                    .price(tradeHistoryData.getPrice()).amount(tradeHistoryData.getSize()).build());
+                    .price(tradeHistoryData.getPrice()).amount(tradeHistoryData.getSize())
+                    .timestamp(tradeHistoryData.getTimestamp()).build());
         });
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/btse/TradeHistoryData.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/btse/TradeHistoryData.java
@@ -13,5 +13,6 @@ class TradeHistoryData {
     private double price;
     @JsonProperty("tradeId")
     private long tradeId;
+    @JsonProperty("timestamp")
     private long timestamp;
 }

--- a/src/main/java/dev/mouradski/ftso/trades/client/bybit/BybitClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bybit/BybitClientEndpoint.java
@@ -53,6 +53,6 @@ public class BybitClientEndpoint extends AbstractClientEndpoint {
 
         var pair = SymbolHelper.getPair(tradeResponse.getParams().getSymbol());
 
-        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(Double.parseDouble(tradeResponse.getData().get("p"))).amount(Double.parseDouble(tradeResponse.getData().get("p"))).build());
+        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(Double.parseDouble(tradeResponse.getData().get("p"))).amount(Double.parseDouble(tradeResponse.getData().get("q"))).build());
     }
 }

--- a/src/main/java/dev/mouradski/ftso/trades/client/bybit/BybitTrade.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bybit/BybitTrade.java
@@ -1,4 +1,6 @@
-package dev.mouradski.ftso.trades.client.binance;
+package dev.mouradski.ftso.trades.client.bybit;
+
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -10,22 +12,20 @@ import lombok.ToString;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-        "s",
-        "p",
-        "q"
+        "topic",
+        "params",
+        "data"
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Getter
 @Setter
 @ToString
-public class Data {
-    @JsonProperty("s")
-    public String s;
-    @JsonProperty("p")
-    public Double p;
-    @JsonProperty("q")
-    public Double q;
-    @JsonProperty("T")
-    public Long t;
+public class BybitTrade {
+    @JsonProperty
+    public String topic;
+    @JsonProperty("params")
+    public Params params;
+    @JsonProperty("data")
+    public Data data;
 
 }

--- a/src/main/java/dev/mouradski/ftso/trades/client/bybit/Data.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bybit/Data.java
@@ -1,4 +1,4 @@
-package dev.mouradski.ftso.trades.client.binance;
+package dev.mouradski.ftso.trades.client.bybit;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -19,13 +19,13 @@ import lombok.ToString;
 @Setter
 @ToString
 public class Data {
-    @JsonProperty("s")
-    public String s;
-    @JsonProperty("p")
-    public Double p;
-    @JsonProperty("q")
-    public Double q;
-    @JsonProperty("T")
+    @JsonProperty("v") // trade id
+    public String v;
+    @JsonProperty("t") // timestamp
     public Long t;
+    @JsonProperty("p") // price
+    public String p;
+    @JsonProperty("q") // quantity
+    public String q;
 
 }

--- a/src/main/java/dev/mouradski/ftso/trades/client/coinbase/CoinbaseClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/coinbase/CoinbaseClientEndpoint.java
@@ -9,6 +9,7 @@ import jakarta.websocket.ClientEndpoint;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -52,6 +53,8 @@ public class CoinbaseClientEndpoint extends AbstractClientEndpoint {
 
         var pair = SymbolHelper.getPair(tradeMatch.getProductId());
 
-        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(tradeMatch.getPrice()).amount(tradeMatch.getSize()).build());
+        var time = Instant.parse(tradeMatch.getTime()).toEpochMilli();
+
+        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(tradeMatch.getPrice()).amount(tradeMatch.getSize()).timestamp(time).build());
     }
 }

--- a/src/main/java/dev/mouradski/ftso/trades/client/coinex/CoinexClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/coinex/CoinexClientEndpoint.java
@@ -61,7 +61,8 @@ public class CoinexClientEndpoint extends AbstractClientEndpoint {
                 .sorted(Comparator.comparing(e -> e.get("time")))
                 .forEach(deal -> trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
                         .price(Double.valueOf(deal.get("price").toString()))
-                        .amount(Double.valueOf(deal.get("amount").toString())).build()));
+                        .amount(Double.valueOf(deal.get("amount").toString()))
+                        .timestamp(Long.valueOf(deal.get("time"))).build()));
 
         return trades;
     }

--- a/src/main/java/dev/mouradski/ftso/trades/client/crypto/CryptoComClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/crypto/CryptoComClientEndpoint.java
@@ -55,7 +55,7 @@ public class CryptoComClientEndpoint extends AbstractClientEndpoint {
         var quote = response.getResult().getSubscription().replace("trade.", "").split("_")[1];
 
         response.getResult().getData().forEach(cryptoTrade -> {
-            trades.add(Trade.builder().exchange(getExchange()).base(base).quote(quote).price(cryptoTrade.getP()).amount(cryptoTrade.getQ()).build());
+            trades.add(Trade.builder().exchange(getExchange()).base(base).quote(quote).price(cryptoTrade.getP()).amount(cryptoTrade.getQ()).timestamp(cryptoTrade.getT()).build());
         });
 
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/digifinex/DigifinexClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/digifinex/DigifinexClientEndpoint.java
@@ -1,6 +1,5 @@
 package dev.mouradski.ftso.trades.client.digifinex;
 
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.mouradski.ftso.trades.client.AbstractClientEndpoint;
 import dev.mouradski.ftso.trades.model.Trade;
@@ -26,7 +25,8 @@ import java.util.stream.Collectors;
 @Component
 public class DigifinexClientEndpoint extends AbstractClientEndpoint {
 
-    protected DigifinexClientEndpoint(TradeService priceSender, @Value("${exchanges}") List<String> exchanges, @Value("${assets}") List<String> assets) {
+    protected DigifinexClientEndpoint(TradeService priceSender, @Value("${exchanges}") List<String> exchanges,
+            @Value("${assets}") List<String> assets) {
         super(priceSender, exchanges, assets);
     }
 
@@ -34,7 +34,6 @@ public class DigifinexClientEndpoint extends AbstractClientEndpoint {
     protected String getUri() {
         return "wss://openapi.digifinex.com/ws/v1/";
     }
-
 
     @Override
     protected void subscribe() {
@@ -45,15 +44,18 @@ public class DigifinexClientEndpoint extends AbstractClientEndpoint {
         getAssets().stream().map(String::toUpperCase).forEach(base -> {
 
             if (markets.contains(base + "_USD")) {
-                this.sendMessage(subscriptionMsgTemplate.replace("ID", incAndGetIdAsString()).replace("PAIRS", "\"" + base + "_USD\""));
+                this.sendMessage(subscriptionMsgTemplate.replace("ID", incAndGetIdAsString()).replace("PAIRS",
+                        "\"" + base + "_USD\""));
             }
 
             if (!base.equals("USDT") && markets.contains(base + "_USDT")) {
-                this.sendMessage(subscriptionMsgTemplate.replace("ID", incAndGetIdAsString()).replace("PAIRS", "\"" + base + "_USDT\""));
+                this.sendMessage(subscriptionMsgTemplate.replace("ID", incAndGetIdAsString()).replace("PAIRS",
+                        "\"" + base + "_USDT\""));
             }
 
             if (!base.equals("USDC") && markets.contains(base + "_USDC")) {
-                this.sendMessage(subscriptionMsgTemplate.replace("ID", incAndGetIdAsString()).replace("PAIRS", "\"" + base + "_USDC\""));
+                this.sendMessage(subscriptionMsgTemplate.replace("ID", incAndGetIdAsString()).replace("PAIRS",
+                        "\"" + base + "_USDC\""));
             }
         });
     }
@@ -81,13 +83,15 @@ public class DigifinexClientEndpoint extends AbstractClientEndpoint {
 
         var tradesArray = gson.toJsonTree(tradeResponse.getParams().get(1)).getAsJsonArray();
 
-
         var pair = SymbolHelper.getPair(gson.toJsonTree(tradeResponse.getParams().get(2)).getAsString());
-
 
         for (var tradeElement : tradesArray) {
             var trade = gson.fromJson(tradeElement, Trade.class);
-            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(trade.getPrice()).amount(trade.getAmount()).build());
+
+            var time = Long.valueOf(Double.valueOf(tradeElement.getAsDouble() * 1000).toString());
+            
+            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
+                    .price(trade.getPrice()).amount(trade.getAmount()).timestamp(time).build());
         }
 
         return trades;
@@ -107,7 +111,8 @@ public class DigifinexClientEndpoint extends AbstractClientEndpoint {
 
             var marketData = gson.fromJson(response.body(), MarketData.class);
 
-            return marketData.getData().stream().map(MarketInfo::getMarket).map(String::toUpperCase).collect(Collectors.toSet());
+            return marketData.getData().stream().map(MarketInfo::getMarket).map(String::toUpperCase)
+                    .collect(Collectors.toSet());
         } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/main/java/dev/mouradski/ftso/trades/client/digifinex/DigifinexTrade.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/digifinex/DigifinexTrade.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Setter
 public class DigifinexTrade {
     private Object id;
-    private Object time;
+    private Double time;
     private Double amount;
     private Double price;
     private String type;

--- a/src/main/java/dev/mouradski/ftso/trades/client/fmfw/FmfwClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/fmfw/FmfwClientEndpoint.java
@@ -56,7 +56,7 @@ public class FmfwClientEndpoint extends AbstractClientEndpoint {
             var pair = SymbolHelper.getPair(e.getKey());
 
             e.getValue().stream().sorted(Comparator.comparing(FmfwTradeResponse.Trade::getT)).forEach(trade -> {
-                trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(trade.getP()).amount(trade.getQ()).build());
+                trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(trade.getP()).amount(trade.getQ()).timestamp(trade.getT()).build());
             });
         });
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/gateio/GateIOClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/gateio/GateIOClientEndpoint.java
@@ -39,7 +39,7 @@ public class GateIOClientEndpoint extends AbstractClientEndpoint {
         var gateIOTrade = gson.fromJson(result, GateIOTrade.class);
 
         return Arrays.asList(Trade.builder().exchange(getExchange()).base(gateIOTrade.getCurrencyPair().split("_")[0])
-                .quote(gateIOTrade.getCurrencyPair().split("_")[1]).price(gateIOTrade.getPrice()).amount(gateIOTrade.getAmount()).build());
+                .quote(gateIOTrade.getCurrencyPair().split("_")[1]).price(gateIOTrade.getPrice()).amount(gateIOTrade.getAmount()).timestamp((long)Double.parseDouble(gateIOTrade.getCreateTimeMs())).build());
 
 
     }

--- a/src/main/java/dev/mouradski/ftso/trades/client/hitbtc/HitbtcClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/hitbtc/HitbtcClientEndpoint.java
@@ -65,7 +65,7 @@ public class HitbtcClientEndpoint extends AbstractClientEndpoint {
 
 
             for (HitbtcTrade hitbtcTrade : e.getValue()) {
-                trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(hitbtcTrade.getP()).amount(hitbtcTrade.getQ()).build());
+                trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(hitbtcTrade.getP()).amount(hitbtcTrade.getQ()).timestamp(hitbtcTrade.getT()).build());
             }
         });
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/huobi/HuobiClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/huobi/HuobiClientEndpoint.java
@@ -54,7 +54,7 @@ public class HuobiClientEndpoint extends AbstractClientEndpoint {
 
         tradeMessage.getTick().getData().stream().sorted(Comparator.comparing(TradeDetail::getTradeId)).forEach(huobiTrade -> trades.add(Trade.builder().exchange(getExchange())
                 .base(pair.getLeft()).quote(pair.getRight()).price(huobiTrade.getPrice())
-                .amount(huobiTrade.getAmount()).build()));
+                .amount(huobiTrade.getAmount()).timestamp(huobiTrade.getTs()).build()));
 
         return trades;
     }

--- a/src/main/java/dev/mouradski/ftso/trades/client/huobi/TradeDetail.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/huobi/TradeDetail.java
@@ -11,7 +11,7 @@ public class TradeDetail {
     private String id;
 
     @SerializedName("ts")
-    private String ts;
+    private long ts;
 
     @SerializedName("tradeId")
     private long tradeId;

--- a/src/main/java/dev/mouradski/ftso/trades/client/kucoin/Data.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/kucoin/Data.java
@@ -40,7 +40,7 @@ public class Data {
     @JsonProperty("takerOrderId")
     public String takerOrderId;
     @JsonProperty("time")
-    public String time;
+    public Double time;
     @JsonProperty("tradeId")
     public String tradeId;
     @JsonProperty("type")

--- a/src/main/java/dev/mouradski/ftso/trades/client/kucoin/KuCoinClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/kucoin/KuCoinClientEndpoint.java
@@ -37,12 +37,16 @@ public class KuCoinClientEndpoint extends AbstractClientEndpoint {
         if (kucoinTrade.getData() == null) {
             return new ArrayList<>();
         }
+
+        var time = (long)(kucoinTrade.getData().getTime()/1e6); // time is in nanoseconds
+
         return Arrays.asList(Trade.builder()
                 .exchange(getExchange())
                 .price(kucoinTrade.getData().getPrice())
                 .amount(kucoinTrade.getData().getSize())
                 .base(kucoinTrade.getData().getSymbol().split("-")[0])
                 .quote(kucoinTrade.getData().getSymbol().split("-")[1])
+                .timestamp(time)
                 .build());
     }
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/lbank/LbankClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/lbank/LbankClientEndpoint.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -58,7 +59,9 @@ public class LbankClientEndpoint extends AbstractClientEndpoint {
 
         var pair = SymbolHelper.getPair(tradeWrapper.getPair());
 
-        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(tradeWrapper.getTrade().getPrice()).amount(tradeWrapper.getTrade().getAmount()).build());
+        var time = Instant.parse(tradeWrapper.getTrade().getTs()).toEpochMilli();
+
+        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(tradeWrapper.getTrade().getPrice()).amount(tradeWrapper.getTrade().getAmount()).timestamp(time).build());
     }
 
     @Scheduled(fixedDelay = 30000)

--- a/src/main/java/dev/mouradski/ftso/trades/client/mexc/MexcClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/mexc/MexcClientEndpoint.java
@@ -57,7 +57,7 @@ public class MexcClientEndpoint extends AbstractClientEndpoint {
 
 
         tradeData.getData().getDeals().stream().sorted(Comparator.comparing(Deal::getT)).forEach(deal -> {
-            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(deal.getP()).amount(deal.getQ()).build());
+            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(deal.getP()).amount(deal.getQ()).timestamp(deal.getT()).build());
         });
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/okex/OkexClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/okex/OkexClientEndpoint.java
@@ -61,7 +61,7 @@ public class OkexClientEndpoint extends AbstractClientEndpoint {
         var trades = new ArrayList<Trade>();
 
         tradeData.getData().forEach(data -> {
-            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(data.getPx()).amount(data.getSz()).build());
+            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(data.getPx()).amount(data.getSz()).timestamp(Long.parseLong(data.getTs())).build());
         });
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/pionex/PionexClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/pionex/PionexClientEndpoint.java
@@ -74,7 +74,7 @@ public class PionexClientEndpoint extends AbstractClientEndpoint {
 
         tradeResponse.getData().forEach(tradeData -> {
             var pair = SymbolHelper.getPair(tradeData.getSymbol());
-            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(tradeData.getPrice()).amount(tradeData.getSize()).build());
+            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(tradeData.getPrice()).amount(tradeData.getSize()).timestamp(tradeData.getTimestamp()).build());
         });
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/toobit/ToobitClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/toobit/ToobitClientEndpoint.java
@@ -53,7 +53,7 @@ public class ToobitClientEndpoint extends AbstractClientEndpoint {
         var pair = SymbolHelper.getPair(tradeMessage.getSymbolName());
 
         ArrayList<Trade> trades = tradeMessage.getTrades().stream().sorted(Comparator.comparing(ToobitTrade::getTime)).map(toobitTrade -> Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
-                .price(toobitTrade.getPrice()).amount(toobitTrade.getQuantity()).build()).collect(Collectors.toCollection(ArrayList::new));
+                .price(toobitTrade.getPrice()).amount(toobitTrade.getQuantity()).timestamp(toobitTrade.getTime()).build()).collect(Collectors.toCollection(ArrayList::new));
 
         return trades;
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/upbit/UpbitClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/upbit/UpbitClientEndpoint.java
@@ -59,6 +59,6 @@ public class UpbitClientEndpoint extends AbstractClientEndpoint {
         var base = trade.getCode().split("-")[1];
         var quote = trade.getCode().split("-")[0];
 
-        return Arrays.asList(Trade.builder().exchange(getExchange()).base(base).quote(quote).price(trade.getTradePrice()).amount(trade.getTradeVolume()).build());
+        return Arrays.asList(Trade.builder().exchange(getExchange()).base(base).quote(quote).price(trade.getTradePrice()).amount(trade.getTradeVolume()).timestamp(trade.getTimestamp()).build());
     }
 }

--- a/src/main/java/dev/mouradski/ftso/trades/client/whitebit/WhitebitClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/whitebit/WhitebitClientEndpoint.java
@@ -75,7 +75,7 @@ public class WhitebitClientEndpoint extends AbstractClientEndpoint {
 
         ((List<Map>) tradeUpdateMessage.getParams().get(1)).stream()
                 .sorted(Comparator.comparing(v -> v.get("time").toString())).forEach(tradeUpdate -> trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
-                        .price(Double.valueOf(tradeUpdate.get("price").toString())).amount(Double.valueOf(tradeUpdate.get("amount").toString())).build()));
+                        .price(Double.valueOf(tradeUpdate.get("price").toString())).amount(Double.valueOf(tradeUpdate.get("amount").toString())).timestamp(((long)(Double.valueOf(tradeUpdate.get("time").toString())*1000))).build()));
 
         return trades;
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/xt/XtClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/xt/XtClientEndpoint.java
@@ -58,7 +58,7 @@ public class XtClientEndpoint extends AbstractClientEndpoint {
 
         var pair = SymbolHelper.getPair(eventData.getEvent().replace("trade@", ""));
 
-        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(eventData.getData().getPrice()).amount(eventData.getData().getQuantity()).build());
+        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(eventData.getData().getPrice()).amount(eventData.getData().getQuantity()).timestamp(eventData.getData().getTime()).build());
     }
 
     @Scheduled(fixedDelay = 20000)

--- a/src/main/java/dev/mouradski/ftso/trades/model/Trade.java
+++ b/src/main/java/dev/mouradski/ftso/trades/model/Trade.java
@@ -14,4 +14,5 @@ public class Trade {
     private String quote;
     private Double amount;
     private String exchange;
+    private Long timestamp;
 }


### PR DESCRIPTION
On exchanges where the API doesn't send any timestamp, the current system time is used. I think this only occurs in Bitfinex and Gate.io

I also added a small fix on the Bybit client regarding params `p` and `q`