### PR TITLE
Force currentTimestamp to all trades sorted and remove btcex

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 ASSETS=xrp,btc,eth,algo,xlm,ada,matic,sol,fil,flr,sgb,doge,xdc,arb,avax,bnb,usdc,busd,usdt
-EXCHANGES=binance,binanceus,bitfinex,bitrue,bitstamp,bybit,coinbase,crypto,digifinex,fmfw,gateio,hitbtc,huobi,kraken,kucoin,lbank,mexc,okex,upbit,btcex,bitmart,bitget,coinex,xt,whitebit,toobit,pionex,btse
+EXCHANGES=binance,binanceus,bitfinex,bitrue,bitstamp,bybit,coinbase,crypto,digifinex,fmfw,gateio,hitbtc,huobi,kraken,kucoin,lbank,mexc,okex,upbit,bitmart,bitget,coinex,xt,whitebit,toobit,pionex,btse

--- a/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
@@ -14,13 +14,12 @@ import java.io.*;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
 
@@ -259,5 +258,9 @@ public abstract class AbstractClientEndpoint {
 
     protected String incAndGetIdAsString() {
         return ((Integer) counter.incrementAndGet()).toString();
+    }
+
+    protected Long currentTimestamp() {
+        return Instant.now().toEpochMilli();
     }
 }

--- a/src/main/java/dev/mouradski/ftso/trades/client/binance/BinanceClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/binance/BinanceClientEndpoint.java
@@ -30,7 +30,7 @@ public class BinanceClientEndpoint extends AbstractClientEndpoint {
 
         Pair<String, String> pair = SymbolHelper.getPair(binanceTrade.getData().getS());
 
-        return Arrays.asList(Trade.builder().timestamp(binanceTrade.getData().getT()).exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
+        return Arrays.asList(Trade.builder().timestamp(currentTimestamp()).exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
                 .price(binanceTrade.getData().getP()).amount(binanceTrade.getData().getQ()).build());
     }
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/bitfinex/BitfinexClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bitfinex/BitfinexClientEndpoint.java
@@ -55,7 +55,7 @@ public class BitfinexClientEndpoint extends AbstractClientEndpoint {
         var pair = channelIds.get(channelId);
 
         return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
-                .price(tradeData.get(3)).amount(Math.abs(tradeData.get(2))).timestamp(System.currentTimeMillis())
+                .price(tradeData.get(3)).amount(Math.abs(tradeData.get(2))).timestamp(currentTimestamp())
                 .build());
     }
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/bitget/BitgetClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bitget/BitgetClientEndpoint.java
@@ -52,7 +52,7 @@ public class BitgetClientEndpoint extends AbstractClientEndpoint {
 
 
         update.getData().forEach(tradeData -> {
-            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).amount(tradeData.getQuantity()).price(tradeData.getPrice()).timestamp(System.currentTimeMillis()).build());
+            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).amount(tradeData.getQuantity()).price(tradeData.getPrice()).timestamp(currentTimestamp()).build());
         });
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/bitget/Update.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bitget/Update.java
@@ -11,4 +11,5 @@ public class Update {
     private String action;
     private Arg arg;
     private List<TradeUpdateData> data;
+    private String ts;
 }

--- a/src/main/java/dev/mouradski/ftso/trades/client/bitmart/BitmartClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bitmart/BitmartClientEndpoint.java
@@ -107,7 +107,7 @@ public class BitmartClientEndpoint extends AbstractClientEndpoint {
                     var pair = SymbolHelper.getPair(tradeData.getSymbol());
                     trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
                             .price(tradeData.getPrice()).amount(tradeData.getSize())
-                            .timestamp(tradeData.getS_t() * 1000) // timestamp is in seconds
+                            .timestamp(currentTimestamp()) // timestamp is in seconds
                             .build());
 
                 });

--- a/src/main/java/dev/mouradski/ftso/trades/client/bitmart/TradeData.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bitmart/TradeData.java
@@ -21,8 +21,5 @@ public class TradeData {
 
     @JsonProperty("symbol")
     private String symbol;
-
-    @JsonProperty("symbol")
-    private Long s_t;
 }
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/bitrue/BitrueClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bitrue/BitrueClientEndpoint.java
@@ -40,7 +40,7 @@ public class BitrueClientEndpoint extends AbstractClientEndpoint {
         var quote = "USDT";
 
         for (var trade : tradeMessage.getTick().getData()) {
-            trades.add(Trade.builder().exchange(getExchange()).price(trade.getPrice()).amount(trade.getAmount()).quote(quote).base(pair).timestamp(trade.getTs()).build());
+            trades.add(Trade.builder().exchange(getExchange()).price(trade.getPrice()).amount(trade.getAmount()).quote(quote).base(pair).timestamp(currentTimestamp()).build());
         }
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/btcex/BtcexClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/btcex/BtcexClientEndpoint.java
@@ -43,6 +43,7 @@ public class BtcexClientEndpoint extends AbstractClientEndpoint {
 
     @Override
     protected List<Trade> mapTrade(String message) throws JsonProcessingException {
+        System.out.println(message);
         if (!message.contains("trade_id")) {
             return new ArrayList<>();
         }
@@ -56,7 +57,7 @@ public class BtcexClientEndpoint extends AbstractClientEndpoint {
 
             trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
                     .price(tradeData.getPrice()).amount(tradeData.getAmount())
-                    .timestamp(Long.parseLong(tradeData.getTimestamp()) * 1000) // timestamp is sent in seconds
+                    .timestamp(currentTimestamp()) // timestamp is sent in seconds
                     .build());
         });
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/btse/BtseClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/btse/BtseClientEndpoint.java
@@ -70,7 +70,7 @@ public class BtseClientEndpoint extends AbstractClientEndpoint {
 
             trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
                     .price(tradeHistoryData.getPrice()).amount(tradeHistoryData.getSize())
-                    .timestamp(tradeHistoryData.getTimestamp()).build());
+                    .timestamp(currentTimestamp()).build());
         });
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/bybit/BybitClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bybit/BybitClientEndpoint.java
@@ -2,12 +2,10 @@ package dev.mouradski.ftso.trades.client.bybit;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.mouradski.ftso.trades.client.AbstractClientEndpoint;
-import dev.mouradski.ftso.trades.client.binance.BinanceTrade;
 import dev.mouradski.ftso.trades.model.Trade;
 import dev.mouradski.ftso.trades.service.TradeService;
 import dev.mouradski.ftso.trades.utils.SymbolHelper;
 import jakarta.websocket.ClientEndpoint;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -60,7 +58,7 @@ public class BybitClientEndpoint extends AbstractClientEndpoint {
 
         Pair<String, String> pair = SymbolHelper.getPair(bybitTrade.getParams().getSymbol());
 
-        return Arrays.asList(Trade.builder().timestamp(bybitTrade.getData().getT()).exchange(getExchange())
+        return Arrays.asList(Trade.builder().timestamp(currentTimestamp()).exchange(getExchange())
                 .base(pair.getLeft()).quote(pair.getRight())
                 .price(Double.parseDouble(bybitTrade.getData().getP()))
                 .amount(Double.parseDouble(bybitTrade.getData().getQ())).build());

--- a/src/main/java/dev/mouradski/ftso/trades/client/bybit/BybitTrade.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bybit/BybitTrade.java
@@ -1,7 +1,5 @@
 package dev.mouradski.ftso.trades.client.bybit;
 
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/dev/mouradski/ftso/trades/client/coinex/CoinexClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/coinex/CoinexClientEndpoint.java
@@ -62,7 +62,7 @@ public class CoinexClientEndpoint extends AbstractClientEndpoint {
                 .forEach(deal -> trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
                         .price(Double.valueOf(deal.get("price").toString()))
                         .amount(Double.valueOf(deal.get("amount").toString()))
-                        .timestamp(Long.valueOf(deal.get("time"))).build()));
+                        .timestamp(currentTimestamp()).build()));
 
         return trades;
     }

--- a/src/main/java/dev/mouradski/ftso/trades/client/crypto/CryptoComClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/crypto/CryptoComClientEndpoint.java
@@ -55,7 +55,7 @@ public class CryptoComClientEndpoint extends AbstractClientEndpoint {
         var quote = response.getResult().getSubscription().replace("trade.", "").split("_")[1];
 
         response.getResult().getData().forEach(cryptoTrade -> {
-            trades.add(Trade.builder().exchange(getExchange()).base(base).quote(quote).price(cryptoTrade.getP()).amount(cryptoTrade.getQ()).timestamp(cryptoTrade.getT()).build());
+            trades.add(Trade.builder().exchange(getExchange()).base(base).quote(quote).price(cryptoTrade.getP()).amount(cryptoTrade.getQ()).timestamp(currentTimestamp()).build());
         });
 
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/digifinex/DigifinexClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/digifinex/DigifinexClientEndpoint.java
@@ -72,7 +72,6 @@ public class DigifinexClientEndpoint extends AbstractClientEndpoint {
 
     @Override
     protected List<Trade> mapTrade(String message) throws JsonProcessingException {
-
         var trades = new ArrayList<Trade>();
 
         var tradeResponse = gson.fromJson(message, TradeResponse.class);
@@ -86,12 +85,10 @@ public class DigifinexClientEndpoint extends AbstractClientEndpoint {
         var pair = SymbolHelper.getPair(gson.toJsonTree(tradeResponse.getParams().get(2)).getAsString());
 
         for (var tradeElement : tradesArray) {
-            var trade = gson.fromJson(tradeElement, Trade.class);
+            var trade = gson.fromJson(tradeElement, DigifinexTrade.class);
 
-            var time = Long.valueOf(Double.valueOf(tradeElement.getAsDouble() * 1000).toString());
-            
             trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
-                    .price(trade.getPrice()).amount(trade.getAmount()).timestamp(time).build());
+                    .price(trade.getPrice()).amount(trade.getAmount()).timestamp(currentTimestamp()).build());
         }
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/digifinex/DigifinexTrade.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/digifinex/DigifinexTrade.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Setter
 public class DigifinexTrade {
     private Object id;
-    private Double time;
+    private Long time;
     private Double amount;
     private Double price;
     private String type;

--- a/src/main/java/dev/mouradski/ftso/trades/client/fmfw/FmfwClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/fmfw/FmfwClientEndpoint.java
@@ -56,7 +56,7 @@ public class FmfwClientEndpoint extends AbstractClientEndpoint {
             var pair = SymbolHelper.getPair(e.getKey());
 
             e.getValue().stream().sorted(Comparator.comparing(FmfwTradeResponse.Trade::getT)).forEach(trade -> {
-                trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(trade.getP()).amount(trade.getQ()).timestamp(trade.getT()).build());
+                trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(trade.getP()).amount(trade.getQ()).timestamp(currentTimestamp()).build());
             });
         });
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/gateio/GateIOClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/gateio/GateIOClientEndpoint.java
@@ -39,7 +39,7 @@ public class GateIOClientEndpoint extends AbstractClientEndpoint {
         var gateIOTrade = gson.fromJson(result, GateIOTrade.class);
 
         return Arrays.asList(Trade.builder().exchange(getExchange()).base(gateIOTrade.getCurrencyPair().split("_")[0])
-                .quote(gateIOTrade.getCurrencyPair().split("_")[1]).price(gateIOTrade.getPrice()).amount(gateIOTrade.getAmount()).timestamp((long)Double.parseDouble(gateIOTrade.getCreateTimeMs())).build());
+                .quote(gateIOTrade.getCurrencyPair().split("_")[1]).price(gateIOTrade.getPrice()).amount(gateIOTrade.getAmount()).timestamp(currentTimestamp()).build());
 
 
     }

--- a/src/main/java/dev/mouradski/ftso/trades/client/gateio/GateIOTrade.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/gateio/GateIOTrade.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 public class GateIOTrade {
     private long id;
     private long createTime;
+    @SerializedName("create_time_ms")
     private String createTimeMs;
     private String side;
     @SerializedName("currency_pair")

--- a/src/main/java/dev/mouradski/ftso/trades/client/hitbtc/HitbtcClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/hitbtc/HitbtcClientEndpoint.java
@@ -65,7 +65,7 @@ public class HitbtcClientEndpoint extends AbstractClientEndpoint {
 
 
             for (HitbtcTrade hitbtcTrade : e.getValue()) {
-                trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(hitbtcTrade.getP()).amount(hitbtcTrade.getQ()).timestamp(hitbtcTrade.getT()).build());
+                trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(hitbtcTrade.getP()).amount(hitbtcTrade.getQ()).timestamp(currentTimestamp()).build());
             }
         });
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/huobi/HuobiClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/huobi/HuobiClientEndpoint.java
@@ -54,7 +54,7 @@ public class HuobiClientEndpoint extends AbstractClientEndpoint {
 
         tradeMessage.getTick().getData().stream().sorted(Comparator.comparing(TradeDetail::getTradeId)).forEach(huobiTrade -> trades.add(Trade.builder().exchange(getExchange())
                 .base(pair.getLeft()).quote(pair.getRight()).price(huobiTrade.getPrice())
-                .amount(huobiTrade.getAmount()).timestamp(huobiTrade.getTs()).build()));
+                .amount(huobiTrade.getAmount()).timestamp(currentTimestamp()).build()));
 
         return trades;
     }

--- a/src/main/java/dev/mouradski/ftso/trades/client/kraken/KrakenClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/kraken/KrakenClientEndpoint.java
@@ -47,7 +47,7 @@ public class KrakenClientEndpoint extends AbstractClientEndpoint {
                 var tradeArray = tradeData.getAsJsonArray();
                 trades.add(Trade.builder().exchange(getExchange()).base(base).quote(quote)
                         .price(tradeArray.get(0).getAsDouble()).amount(tradeArray.get(1).getAsDouble())
-                        .timestamp((long) (tradeArray.get(2).getAsDouble() * 1000)) // timestamp sent in seconds
+                        .timestamp(currentTimestamp()) // timestamp sent in seconds
                         .build());
             }
         }

--- a/src/main/java/dev/mouradski/ftso/trades/client/kucoin/KuCoinClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/kucoin/KuCoinClientEndpoint.java
@@ -38,15 +38,13 @@ public class KuCoinClientEndpoint extends AbstractClientEndpoint {
             return new ArrayList<>();
         }
 
-        var time = (long)(kucoinTrade.getData().getTime()/1e6); // time is in nanoseconds
-
         return Arrays.asList(Trade.builder()
                 .exchange(getExchange())
                 .price(kucoinTrade.getData().getPrice())
                 .amount(kucoinTrade.getData().getSize())
                 .base(kucoinTrade.getData().getSymbol().split("-")[0])
                 .quote(kucoinTrade.getData().getSymbol().split("-")[1])
-                .timestamp(time)
+                .timestamp(currentTimestamp())
                 .build());
     }
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/lbank/LbankClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/lbank/LbankClientEndpoint.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -59,9 +58,7 @@ public class LbankClientEndpoint extends AbstractClientEndpoint {
 
         var pair = SymbolHelper.getPair(tradeWrapper.getPair());
 
-        var time = Instant.parse(tradeWrapper.getTrade().getTs()).toEpochMilli();
-
-        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(tradeWrapper.getTrade().getPrice()).amount(tradeWrapper.getTrade().getAmount()).timestamp(time).build());
+        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(tradeWrapper.getTrade().getPrice()).amount(tradeWrapper.getTrade().getAmount()).timestamp(currentTimestamp()).build());
     }
 
     @Scheduled(fixedDelay = 30000)

--- a/src/main/java/dev/mouradski/ftso/trades/client/mexc/MexcClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/mexc/MexcClientEndpoint.java
@@ -57,7 +57,7 @@ public class MexcClientEndpoint extends AbstractClientEndpoint {
 
 
         tradeData.getData().getDeals().stream().sorted(Comparator.comparing(Deal::getT)).forEach(deal -> {
-            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(deal.getP()).amount(deal.getQ()).timestamp(deal.getT()).build());
+            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(deal.getP()).amount(deal.getQ()).timestamp(currentTimestamp()).build());
         });
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/okex/OkexClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/okex/OkexClientEndpoint.java
@@ -61,7 +61,7 @@ public class OkexClientEndpoint extends AbstractClientEndpoint {
         var trades = new ArrayList<Trade>();
 
         tradeData.getData().forEach(data -> {
-            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(data.getPx()).amount(data.getSz()).timestamp(Long.parseLong(data.getTs())).build());
+            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(data.getPx()).amount(data.getSz()).timestamp(currentTimestamp()).build());
         });
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/pionex/PionexClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/pionex/PionexClientEndpoint.java
@@ -74,7 +74,7 @@ public class PionexClientEndpoint extends AbstractClientEndpoint {
 
         tradeResponse.getData().forEach(tradeData -> {
             var pair = SymbolHelper.getPair(tradeData.getSymbol());
-            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(tradeData.getPrice()).amount(tradeData.getSize()).timestamp(tradeData.getTimestamp()).build());
+            trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(tradeData.getPrice()).amount(tradeData.getSize()).timestamp(currentTimestamp()).build());
         });
 
         return trades;

--- a/src/main/java/dev/mouradski/ftso/trades/client/toobit/ToobitClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/toobit/ToobitClientEndpoint.java
@@ -53,7 +53,7 @@ public class ToobitClientEndpoint extends AbstractClientEndpoint {
         var pair = SymbolHelper.getPair(tradeMessage.getSymbolName());
 
         ArrayList<Trade> trades = tradeMessage.getTrades().stream().sorted(Comparator.comparing(ToobitTrade::getTime)).map(toobitTrade -> Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
-                .price(toobitTrade.getPrice()).amount(toobitTrade.getQuantity()).timestamp(toobitTrade.getTime()).build()).collect(Collectors.toCollection(ArrayList::new));
+                .price(toobitTrade.getPrice()).amount(toobitTrade.getQuantity()).timestamp(currentTimestamp()).build()).collect(Collectors.toCollection(ArrayList::new));
 
         return trades;
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/upbit/UpbitClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/upbit/UpbitClientEndpoint.java
@@ -59,6 +59,6 @@ public class UpbitClientEndpoint extends AbstractClientEndpoint {
         var base = trade.getCode().split("-")[1];
         var quote = trade.getCode().split("-")[0];
 
-        return Arrays.asList(Trade.builder().exchange(getExchange()).base(base).quote(quote).price(trade.getTradePrice()).amount(trade.getTradeVolume()).timestamp(trade.getTimestamp()).build());
+        return Arrays.asList(Trade.builder().exchange(getExchange()).base(base).quote(quote).price(trade.getTradePrice()).amount(trade.getTradeVolume()).timestamp(currentTimestamp()).build());
     }
 }

--- a/src/main/java/dev/mouradski/ftso/trades/client/whitebit/WhitebitClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/whitebit/WhitebitClientEndpoint.java
@@ -75,7 +75,7 @@ public class WhitebitClientEndpoint extends AbstractClientEndpoint {
 
         ((List<Map>) tradeUpdateMessage.getParams().get(1)).stream()
                 .sorted(Comparator.comparing(v -> v.get("time").toString())).forEach(tradeUpdate -> trades.add(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight())
-                        .price(Double.valueOf(tradeUpdate.get("price").toString())).amount(Double.valueOf(tradeUpdate.get("amount").toString())).timestamp(((long)(Double.valueOf(tradeUpdate.get("time").toString())*1000))).build()));
+                        .price(Double.valueOf(tradeUpdate.get("price").toString())).amount(Double.valueOf(tradeUpdate.get("amount").toString())).timestamp(currentTimestamp()).build()));
 
         return trades;
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/xt/XtClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/xt/XtClientEndpoint.java
@@ -58,7 +58,7 @@ public class XtClientEndpoint extends AbstractClientEndpoint {
 
         var pair = SymbolHelper.getPair(eventData.getEvent().replace("trade@", ""));
 
-        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(eventData.getData().getPrice()).amount(eventData.getData().getQuantity()).timestamp(eventData.getData().getTime()).build());
+        return Arrays.asList(Trade.builder().exchange(getExchange()).base(pair.getLeft()).quote(pair.getRight()).price(eventData.getData().getPrice()).amount(eventData.getData().getQuantity()).timestamp(currentTimestamp()).build());
     }
 
     @Scheduled(fixedDelay = 20000)

--- a/src/test/java/dev/mouradski/ftso/trades/utils/SymbolHelperTest.java
+++ b/src/test/java/dev/mouradski/ftso/trades/utils/SymbolHelperTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SymbolHelperTest {
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,4 +2,4 @@ spring.servlet.async.enabled=true
 serve.websocket=false
 
 assets=xrp,btc,eth,algo,xlm,ada,matic,sol,fil,flr,sgb,doge,xdc,arb,avax,bnb,usdc,busd,usdt
-exchanges=binance,binanceus,bitfinex,bitrue,bitstamp,bybit,coinbase,crypto,digifinex,fmfw,gateio,hitbtc,huobi,kraken,kucoin,lbank,mexc,okex,upbit,btcex,bitmart,bitget,coinex,xt,whitebit,toobit,pionex,btse
+exchanges=binance,binanceus,bitfinex,bitrue,bitstamp,bybit,coinbase,crypto,digifinex,fmfw,gateio,hitbtc,huobi,kraken,kucoin,lbank,mexc,okex,upbit,bitmart,bitget,coinex,xt,whitebit,toobit,pionex,btse


### PR DESCRIPTION
Removing btcex

Force timestamp to currentTimestamp() to avoid different timezones from exchanges

the mapTrade method sorts the trades according to their IDs or their timestamp, so we shouldn't have to worry about order, and using the currentTimestamp() allows us to have consistency in the data we will send to WS clients

@JamesGDiaz 