### PR TITLE
Add some log messages here and there to improve verbosity and modify the connect() function. Details below

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 ASSETS=xrp,btc,eth,algo,xlm,ada,matic,sol,fil,ltc,flr,sgb,doge,xdc,arb,avax,bnb,usdc,busd,usdt,bch,dgb
-EXCHANGES=binance,binanceus,bitfinex,bitrue,bitstamp,bybit,coinbase,crypto,fmfw,gateio,hitbtc,huobi,kraken,lbank,mexc,okex,upbit,bitmart,bitget,coinex,xt,whitebit,toobit,pionex,btse,bitforex,bingx,p2b
+EXCHANGES=binance,binanceus,bitfinex,bitrue,bitstamp,digifinex,bybit,coinbase,crypto,fmfw,gateio,hitbtc,huobi,kraken,lbank,mexc,okex,upbit,bitmart,bitget,coinex,xt,whitebit,toobit,pionex,btse,bitforex,bingx,p2b
 AGGREGATOR_PORT=8986
 SUBSCRIBE_TRADE=true
 SUBSCRIBE_TICKER=true

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 ASSETS=xrp,btc,eth,algo,xlm,ada,matic,sol,fil,ltc,flr,sgb,doge,xdc,arb,avax,bnb,usdc,busd,usdt,bch,dgb
-EXCHANGES=binance,binanceus,bitfinex,bitrue,bitstamp,digifinex,bybit,coinbase,crypto,fmfw,gateio,hitbtc,huobi,kraken,lbank,mexc,okex,upbit,bitmart,bitget,coinex,xt,whitebit,toobit,pionex,btse,bitforex,bingx,p2b
+EXCHANGES=binance,binanceus,bitfinex,bitrue,bitstamp,bybit,coinbase,crypto,fmfw,gateio,hitbtc,huobi,kraken,lbank,mexc,okex,upbit,bitmart,bitget,coinex,xt,whitebit,toobit,pionex,btse,bitforex,bingx,p2b
 AGGREGATOR_PORT=8986
 SUBSCRIBE_TRADE=true
 SUBSCRIBE_TICKER=true

--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ EXCHANGES=binance,binanceus,bitfinex,bitrue,bitstamp,bybit,coinbase,crypto,fmfw,
 AGGREGATOR_PORT=8986
 SUBSCRIBE_TRADE=true
 SUBSCRIBE_TICKER=true
+MESSAGE_TIMEOUT=30

--- a/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
@@ -269,7 +269,8 @@ public abstract class AbstractClientEndpoint {
                     container.connectToServer(this, new URI(getUri()));
                 } catch (Exception e) {
                     var waitTime = Math.round(Math.pow(2, reconnectAttemptCount)) * 1000;
-                    log.error("Unable to connect to {}, waiting {} seconds to try again", getExchange(), waitTime/1000);
+                    log.error("Unable to connect to {}, waiting {} seconds to try again", getExchange(),
+                            waitTime / 1000);
                     log.error(e.getMessage(), e.getStackTrace().toString());
                     try {
                         // implement exponential backoff up to 2^18 seconds ()
@@ -280,7 +281,7 @@ public abstract class AbstractClientEndpoint {
                 }
                 connected = true;
             }
-        } while (connected == false);
+        } while (!connected);
 
         log.info("Connected to {}", getExchange());
         return true;

--- a/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
@@ -269,7 +269,7 @@ public abstract class AbstractClientEndpoint {
                     container.connectToServer(this, new URI(getUri()));
                 } catch (Exception e) {
                     var waitTime = Math.round(Math.pow(2, reconnectAttemptCount)) * 1000;
-                    log.error("Unable to connect to {}, waiting {} seconds to try again", getExchange(), waitTime);
+                    log.error("Unable to connect to {}, waiting {} seconds to try again", getExchange(), waitTime/1000);
                     log.error(e.getMessage(), e.getStackTrace().toString());
                     try {
                         // implement exponential backoff up to 2^18 seconds ()

--- a/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
@@ -45,7 +45,10 @@ public abstract class AbstractClientEndpoint {
     protected List<String> exchanges;
 
     public static final Gson gson = new Gson();
-    private static final long DEFAULT_TIMEOUT_IN_SECONDS = 120; // timeout in seconds
+
+    @ConfigProperty(name = "default_message_timeout", defaultValue = "30")
+    private static long DEFAULT_TIMEOUT_IN_SECONDS; // timeout in seconds
+
     protected final ObjectMapper objectMapper = new ObjectMapper();
 
     protected Session userSession = null;
@@ -68,7 +71,8 @@ public abstract class AbstractClientEndpoint {
         this.userSession = userSession;
         var executor = Executors.newSingleThreadScheduledExecutor();
         executor.scheduleAtFixedRate(() -> {
-            if (subscribeTrade && this.userSession != null && this.userSession.isOpen() && System.currentTimeMillis() - lastTradeTime > getTimeout() * 1000) {
+            if (subscribeTrade && this.userSession != null && this.userSession.isOpen()
+                    && System.currentTimeMillis() - lastTradeTime > getTimeout() * 1000) {
 
                 log.info("No trade received from {} for {} seconds. Reconnecting...", getExchange(), getTimeout());
 
@@ -76,7 +80,8 @@ public abstract class AbstractClientEndpoint {
                         new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, "No data received in a while"));
             }
 
-            if (subscribeTicker && !httpTicker() && this.userSession != null && this.userSession.isOpen() && System.currentTimeMillis() - lastTickerTime > getTimeout() * 1000) {
+            if (subscribeTicker && !httpTicker() && this.userSession != null && this.userSession.isOpen()
+                    && System.currentTimeMillis() - lastTickerTime > getTimeout() * 1000) {
                 log.info("No ticker received from {} for {} seconds. Reconnecting...", getExchange(), getTimeout());
 
                 onClose(userSession, new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, "Timeout"));

--- a/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
@@ -264,9 +264,9 @@ public abstract class AbstractClientEndpoint {
 
             try {
                 var container = ContainerProvider.getWebSocketContainer();
+                // throws if connection is unsuccesful
                 container.connectToServer(this, new URI(getUri()));
 
-                // throws if connection is unsuccesful
                 log.info("Connected to {}", getExchange());
                 return true;
             } catch (Exception e) {

--- a/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
@@ -95,8 +95,6 @@ public abstract class AbstractClientEndpoint {
             Thread.sleep(2000);
             this.userSession = null;
         } catch (Exception e) {
-            log.info("An exception occured while reconnecting to {}", getExchange());
-            log.error(e.getMessage(), e.getStackTrace().toString());
         }
 
         connect();

--- a/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
@@ -46,8 +46,9 @@ public abstract class AbstractClientEndpoint {
 
     public static final Gson gson = new Gson();
 
+    @Inject
     @ConfigProperty(name = "default_message_timeout", defaultValue = "30")
-    private static long DEFAULT_TIMEOUT_IN_SECONDS; // timeout in seconds
+    private long DEFAULT_TIMEOUT_IN_SECONDS; // timeout in seconds
 
     protected final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
@@ -74,15 +74,12 @@ public abstract class AbstractClientEndpoint {
 
                 onClose(userSession,
                         new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, "No data received in a while"));
-
             }
 
             if (subscribeTicker && !httpTicker() && this.userSession != null && this.userSession.isOpen() && System.currentTimeMillis() - lastTickerTime > getTimeout() * 1000) {
                 log.info("No ticker received from {} for {} seconds. Reconnecting...", getExchange(), getTimeout());
 
                 onClose(userSession, new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, "Timeout"));
-
-                connect();
             }
 
         }, getTimeout(), getTimeout(), TimeUnit.SECONDS);

--- a/src/main/java/dev/mouradski/ftso/trades/client/bitrue/BitrueClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/bitrue/BitrueClientEndpoint.java
@@ -85,7 +85,7 @@ public class BitrueClientEndpoint extends AbstractClientEndpoint {
 
     @Override
     protected long getTimeout() {
-        return 300;
+        return 30;
     }
 
     @Override

--- a/src/main/java/dev/mouradski/ftso/trades/server/WsServer.java
+++ b/src/main/java/dev/mouradski/ftso/trades/server/WsServer.java
@@ -17,12 +17,14 @@ public abstract class WsServer<T> {
 
     @OnOpen
     public void onOpen(Session session) {
+        log.info("Client connected to {} channel", session.getRequestURI());
         this.session = session;
         this.getListeners().add(this);
     }
 
     @OnClose
     public void onClose(Session session) {
+        log.info("Client disconnected from {} channel", session.getRequestURI());
         getListeners().remove(this);
     }
 
@@ -48,5 +50,6 @@ public abstract class WsServer<T> {
             log.error("Caught exception while sending message to Session " + this.session.getId(), e.getMessage(), e);
         }
     }
+
     protected abstract Set<WsServer<T>> getListeners();
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,4 @@ exchanges=${EXCHANGES}
 quarkus.http.port=${AGGREGATOR_PORT}
 subscribe.trade=${SUBSCRIBE_TRADE}
 subscribe.ticker=${SUBSCRIBE_TICKER}
+default_message_timeout=${MESSAGE_TIMEOUT}


### PR DESCRIPTION
If the connect() function is unable to connect to the websocket for whatever reason, e.g. network failure, exchange maintenance etc, it won't attempt to reconnect until the scheduled thread checks for timeouts.

This new function will attempt reconnects until succesful, granted it should still have an exponential backoff function, currently it tries every 10 seconds, and it should play nicely with the scheduled timeout detector.

I also lowered the timeout to 30 seconds and added it as a possible env var, I think 120 seconds is way too long for the FTSO, imagine not receiving data for 2 minutes if theres a single hiccup in your internet connectivity, 30 seconds is still too long for my taste but its better.