### PR TITLE
silent websocket shcedule fix

### DIFF
--- a/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
+++ b/src/main/java/dev/mouradski/ftso/trades/client/AbstractClientEndpoint.java
@@ -145,12 +145,9 @@ public abstract class AbstractClientEndpoint {
         timeoutFuture.cancel(false);
 
         if (timeoutFuture.isCancelled() || timeoutFuture.isDone()) {
-            log.info("scheduled");
             timeoutFuture = timeoutExecutor.scheduleAtFixedRate(this::checkMessageReceivedTimeout, getTimeout(),
                     getTimeout(),
                     TimeUnit.SECONDS);
-        } else {
-            log.warn("NOT scheduled");
         }
     }
 


### PR DESCRIPTION
Changed to fixed rate scheduler to avoid situations when the last received message was unable to schedule a new check, therefore having the possibility of the last timeoutCheck having a more recent last trade/ticker timestamp and not scheduling a new check.

I think this is what's happenning on Binance and Coinbase on #18 